### PR TITLE
Cleanup & optimization

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,11 +1,7 @@
 local QBCore = exports['qb-core']:GetCoreObject()
-local housePlants = {}
-local insideHouse = false
-local currentHouse = nil
-local plantSpawned = false
-local ClosestTarget = 0
+local housePlants, currentHouse, plantSpawned, closestPlant = {}, nil, false, 0
 
-local DrawText3Ds = function(x, y, z, text)
+local function drawText3Ds(x, y, z, text)
     SetTextScale(0.35, 0.35)
     SetTextFont(4)
     SetTextProportional(1)
@@ -21,286 +17,227 @@ local DrawText3Ds = function(x, y, z, text)
 end
 
 local function spawnHousePlants()
+    if not currentHouse or plantSpawned or not housePlants[currentHouse] then return end
     CreateThread(function()
-        if not plantSpawned and currentHouse then
-            for k in pairs(housePlants[currentHouse]) do
-                local plantData = {
-                    ["plantCoords"] = json.decode(housePlants[currentHouse][k].coords),
-                    ["plantProp"] = GetHashKey(QBWeed.Plants[housePlants[currentHouse][k].sort]["stages"][housePlants[currentHouse][k].stage]),
-                }
+        for k in pairs(housePlants[currentHouse]) do
+            local plantData = {
+                ["plantCoords"] = json.decode(housePlants[currentHouse][k].coords),
+                ["plantProp"] = joaat(QBWeed.Plants[housePlants[currentHouse][k].sort].stages[housePlants[currentHouse][k].stage]),
+            }
 
-                local plantProp = CreateObject(plantData["plantProp"], plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z, false, false, false)
-                while not plantProp do Wait(0) end
-                PlaceObjectOnGroundProperly(plantProp)
-                Wait(10)
-                FreezeEntityPosition(plantProp, true)
-                SetEntityAsMissionEntity(plantProp, false, false)
+            local plantProp = CreateObject(plantData["plantProp"], plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z, false, false, false)
+            while not plantProp do Wait(0) end
+            PlaceObjectOnGroundProperly(plantProp)
+            Wait(10)
+            FreezeEntityPosition(plantProp, true)
+            SetEntityAsMissionEntity(plantProp, false, false)
+        end
+        plantSpawned = true
+    end)
+end
+
+local function updateHousePlants(leftHouse)
+    if not plantSpawned or not currentHouse then return end
+    CreateThread(function()
+        for k in pairs(housePlants[currentHouse]) do
+            local plantData = {
+                ["plantCoords"] = json.decode(housePlants[currentHouse][k].coords),
+            }
+
+            for _, stage in pairs(QBWeed.Plants[housePlants[currentHouse][k].sort]["stages"]) do
+                local oldPlant = GetClosestObjectOfType(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z, 3.5, GetHashKey(stage), false, false, false)
+                if oldPlant ~= 0 then
+                    DeleteObject(oldPlant)
+                end
             end
-            plantSpawned = true
+        end
+        plantSpawned = false
+        if leftHouse then
+            housePlants[currentHouse] = nil
+            currentHouse = nil
+        else
+            QBCore.Functions.TriggerCallback('qb-weed:server:getBuildingPlants', function(plants)
+                housePlants[currentHouse] = plants
+                spawnHousePlants()
+            end, currentHouse)
         end
     end)
 end
 
-local function despawnHousePlants()
-    CreateThread(function()
-        if plantSpawned then
-            for k in pairs(housePlants[currentHouse]) do
-                local plantData = {
-                    ["plantCoords"] = json.decode(housePlants[currentHouse][k].coords),
-                }
+local function getPlantData()
+    return {
+        ["plantCoords"] = json.decode(housePlants[currentHouse][closestPlant].coords),
+        ["plantStage"] = housePlants[currentHouse][closestPlant].stage,
+        ["plantProp"] = GetHashKey(QBWeed.Plants[housePlants[currentHouse][closestPlant].sort]["stages"][housePlants[currentHouse][closestPlant].stage]),
+        ["plantSort"] = {
+            ["name"] = housePlants[currentHouse][closestPlant].sort,
+            ["label"] = QBWeed.Plants[housePlants[currentHouse][closestPlant].sort]["label"],
+        },
+        ["plantStats"] = {
+            ["food"] = housePlants[currentHouse][closestPlant].food,
+            ["health"] = housePlants[currentHouse][closestPlant].health,
+            ["progress"] = housePlants[currentHouse][closestPlant].progress,
+            ["stage"] = housePlants[currentHouse][closestPlant].stage,
+            ["highestStage"] = QBWeed.Plants[housePlants[currentHouse][closestPlant].sort]["highestStage"],
+            ["gender"] = (housePlants[currentHouse][closestPlant].gender == "woman") and "F" or "M",
+            ["plantId"] = housePlants[currentHouse][closestPlant].plantid,
+        }
+    }
+end
 
-                for _, stage in pairs(QBWeed.Plants[housePlants[currentHouse][k].sort]["stages"]) do
-                    local closestPlant = GetClosestObjectOfType(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z, 3.5, GetHashKey(stage), false, false, false)
-                    if closestPlant ~= 0 then
-                        DeleteObject(closestPlant)
-                    end
+local function inHouse()
+    CreateThread(function()
+        while currentHouse do
+            local plyCoords = GetEntityCoords(PlayerPedId())
+            closestPlant = 0
+
+            for k in pairs(housePlants[currentHouse]) do
+                local plantCoords = json.decode(housePlants[currentHouse][k].coords)
+                if #(plyCoords - vector3(plantCoords.x, plantCoords.y, plantCoords.z)) < 0.8 then
+                    closestPlant = k
+                    break
                 end
             end
-            plantSpawned = false
+            Wait(100)
+        end
+    end)
+    CreateThread(function()
+        while currentHouse do
+            Wait(0)
+            if plantSpawned and closestPlant ~= 0 then
+                local plantData, status = getPlantData(), 0
+                local plantInfoLabel = Lang:t('text.sort')..' ~g~' ..plantData["plantSort"]["label"]..'~w~ ['..plantData["plantStats"]["gender"]..'] | '..Lang:t('text.nutrition')..' ~b~'..plantData["plantStats"]["food"]..'% ~w~ | '..Lang:t('text.health')..' ~b~'..plantData["plantStats"]["health"]..'%'
+                local plantStageLabel = Lang:t('text.stage').. ' ~b~' .. QBWeed.StageLabels[plantData["plantStats"]["stage"]] ..' ~w~' ..Lang:t('text.progress')..' ~b~'..plantData["plantStats"]["progress"]..'% ~w~ / ' ..Lang:t('text.highestStage') .. ' ~b~' .. QBWeed.StageLabels[plantData["plantStats"]["highestStage"]]
+                local plantActionLabel
+
+                if plantData["plantStats"]["health"] > 0 and plantData["plantStage"] == plantData["plantStats"]["highestStage"] then
+                    status = 1
+                    plantStageLabel = nil
+                    plantActionLabel = Lang:t('text.harvest_plant')
+                elseif plantData["plantStats"]["health"] == 0 then
+                    status = 2
+                    plantStageLabel = nil
+                    plantActionLabel = Lang:t('error.plant_has_died')
+                end
+
+                if plantInfoLabel then drawText3Ds(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z, plantInfoLabel) end
+                if plantStageLabel and QBWeed.ShowStages then drawText3Ds(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z - 0.1, plantStageLabel) end
+                if plantActionLabel then drawText3Ds(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z + 0.2, plantActionLabel) end
+
+                if status > 0 and IsControlJustPressed(0, 38) then
+                    local ped = PlayerPedId()
+
+                    QBCore.Functions.Progressbar("remove_weed_plant", Lang:t((status == 1) and 'text.harvesting_plant' or 'text.removing_the_plant'), 8000, false, true, {
+                        disableMovement = true,
+                        disableCarMovement = true,
+                        disableMouse = false,
+                        disableCombat = true,
+                    }, {
+                        animDict = "amb@world_human_gardener_plant@male@base",
+                        anim = "base",
+                        flags = 16,
+                    }, {}, {}, function() -- Done
+                        ClearPedTasks(ped)
+                        if status == 1 then
+                            local amount = math.random(1, (plantData["plantStats"]["gender"] == "M") and 2 or 6)
+                            TriggerServerEvent('qb-weed:server:harvestPlant', currentHouse, amount, plantData["plantSort"]["name"], plantData["plantStats"]["plantId"])
+                        else
+                            TriggerServerEvent('qb-weed:server:removeDeathPlant', currentHouse, plantData["plantStats"]["plantId"])
+                        end
+                    end, function() -- Cancel
+                        ClearPedTasks(ped)
+                        QBCore.Functions.Notify(Lang:t('error.process_canceled'), "error")
+                    end)
+                end
+            else
+                Wait(100)
+            end
         end
     end)
 end
 
 RegisterNetEvent('qb-weed:client:getHousePlants', function(house)
     QBCore.Functions.TriggerCallback('qb-weed:server:getBuildingPlants', function(plants)
-        if not plants then return end
         currentHouse = house
         housePlants[currentHouse] = plants
-        insideHouse = true
         spawnHousePlants()
+        inHouse()
     end, house)
 end)
 
-CreateThread(function()
-    while true do
-        Wait(0)
-        if insideHouse and plantSpawned then
-            local ped = PlayerPedId()
-            for k in pairs(housePlants[currentHouse]) do
-                local gender = (housePlants[currentHouse][k].gender == "woman") and "F" or "M"
-
-                local plantData = {
-                    ["plantCoords"] = json.decode(housePlants[currentHouse][k].coords),
-                    ["plantStage"] = housePlants[currentHouse][k].stage,
-                    ["plantProp"] = GetHashKey(QBWeed.Plants[housePlants[currentHouse][k].sort]["stages"][housePlants[currentHouse][k].stage]),
-                    ["plantSort"] = {
-                        ["name"] = housePlants[currentHouse][k].sort,
-                        ["label"] = QBWeed.Plants[housePlants[currentHouse][k].sort]["label"],
-                    },
-                    ["plantStats"] = {
-                        ["food"] = housePlants[currentHouse][k].food,
-                        ["health"] = housePlants[currentHouse][k].health,
-                        ["progress"] = housePlants[currentHouse][k].progress,
-                        ["stage"] = housePlants[currentHouse][k].stage,
-                        ["highestStage"] = QBWeed.Plants[housePlants[currentHouse][k].sort]["highestStage"],
-                        ["gender"] = gender,
-                        ["plantId"] = housePlants[currentHouse][k].plantid,
-                    }
-                }
-
-                local plyDistance = #(GetEntityCoords(ped) - vector3(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z))
-
-                if plyDistance < 0.8 then
-                    ClosestTarget = k
-                    if plantData["plantStats"]["health"] > 0 then
-                        if plantData["plantStage"] ~= plantData["plantStats"]["highestStage"] then
-                            DrawText3Ds(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z, Lang:t('text.sort')..' ~g~' ..plantData["plantSort"]["label"]..'~w~ ['..plantData["plantStats"]["gender"]..'] | '..Lang:t('text.nutrition')..' ~b~'..plantData["plantStats"]["food"]..'% ~w~ | '..Lang:t('text.health')..' ~b~'..plantData["plantStats"]["health"]..'%')
-                            if QBWeed.showStages == true then
-                                DrawText3Ds(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z - 0.1, Lang:t('text.stage').. ' ~b~' ..plantData["plantStats"]["stage"]..' ~w~' ..Lang:t('text.progress')..' ~b~'..plantData["plantStats"]["progress"]..'% ~w~ / ' ..Lang:t('text.highestStage') .. ' ~b~' ..plantData["plantStats"]["highestStage"])
-                            end
-                        else
-                            DrawText3Ds(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z + 0.2, Lang:t('text.harvest_plant'))
-                            DrawText3Ds(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z, Lang:t('text.sort')..' ~g~'..plantData["plantSort"]["label"]..'~w~ ['..plantData["plantStats"]["gender"]..'] | '..Lang:t('text.nutrition')..' ~b~'..plantData["plantStats"]["food"]..'% ~w~ | '..Lang:t('text.health')..' ~b~'..plantData["plantStats"]["health"]..'%')
-                            if IsControlJustPressed(0, 38) then
-                                QBCore.Functions.Progressbar("remove_weed_plant", Lang:t('text.harvesting_plant'), 8000, false, true, {
-                                    disableMovement = true,
-                                    disableCarMovement = true,
-                                    disableMouse = false,
-                                    disableCombat = true,
-                                }, {
-                                    animDict = "amb@world_human_gardener_plant@male@base",
-                                    anim = "base",
-                                    flags = 16,
-                                }, {}, {}, function() -- Done
-                                    ClearPedTasks(ped)
-                                    local amount = math.random(1, 6)
-                                    if plantData["plantStats"]["gender"] == "M" then
-                                        amount = math.random(1, 2)
-                                    end
-                                    TriggerServerEvent('qb-weed:server:harvestPlant', currentHouse, amount, plantData["plantSort"]["name"], plantData["plantStats"]["plantId"])
-                                end, function() -- Cancel
-                                    ClearPedTasks(ped)
-                                    QBCore.Functions.Notify("Process Canceled", "error")
-                                end)
-                            end
-                        end
-                    elseif plantData["plantStats"]["health"] == 0 then
-                        DrawText3Ds(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z, Lang:t('error.plant_has_died'))
-                        if IsControlJustPressed(0, 38) then
-                            QBCore.Functions.Progressbar("remove_weed_plant", Lang:t('text.removing_the_plant'), 8000, false, true, {
-                                disableMovement = true,
-                                disableCarMovement = true,
-                                disableMouse = false,
-                                disableCombat = true,
-                            }, {
-                                animDict = "amb@world_human_gardener_plant@male@base",
-                                anim = "base",
-                                flags = 16,
-                            }, {}, {}, function() -- Done
-                                ClearPedTasks(ped)
-                                TriggerServerEvent('qb-weed:server:removeDeathPlant', currentHouse, plantData["plantStats"]["plantId"])
-                            end, function() -- Cancel
-                                ClearPedTasks(ped)
-                                QBCore.Functions.Notify(Lang:t('error.process_canceled'), "error")
-                            end)
-                        end
-                    end
-                end
-            end
-        elseif not insideHouse then
-            Wait(5000)
-        end
-    end
-end)
-
 RegisterNetEvent('qb-weed:client:leaveHouse', function()
-    despawnHousePlants()
-    SetTimeout(1000, function()
-        if currentHouse ~= nil then
-            insideHouse = false
-            housePlants[currentHouse] = nil
-            currentHouse = nil
-        end
-    end)
+    updateHousePlants(true)
 end)
 
 RegisterNetEvent('qb-weed:client:refreshHousePlants', function(house)
-    if currentHouse and currentHouse == house then
-        despawnHousePlants()
-        SetTimeout(100, function()
-            QBCore.Functions.TriggerCallback('qb-weed:server:getBuildingPlants', function(plants)
-                currentHouse = house
-                housePlants[currentHouse] = plants
-                spawnHousePlants()
-            end, house)
-        end)
-    end
-end)
-
-RegisterNetEvent('qb-weed:client:refreshPlantStats', function()
-    if insideHouse and currentHouse then
-        despawnHousePlants()
-        SetTimeout(100, function()
-            QBCore.Functions.TriggerCallback('qb-weed:server:getBuildingPlants', function(plants)
-                housePlants[currentHouse] = plants
-                spawnHousePlants()
-            end, currentHouse)
-        end)
+    if currentHouse == house or not house then
+        updateHousePlants(false)
     end
 end)
 
 RegisterNetEvent('qb-weed:client:placePlant', function(type, item)
+    if not currentHouse then QBCore.Functions.Notify(Lang:t('error.not_safe_here'), 'error', 3500) return end
+    if closestPlant ~= 0 then QBCore.Functions.Notify(Lang:t('error.cant_place_here'), 'error', 3500) return end
     local ped = PlayerPedId()
-    local plyCoords = GetOffsetFromEntityInWorldCoords(ped, 0, 0.75, 0)
+    local plantCoords = GetOffsetFromEntityInWorldCoords(ped, 0, 0.75, 0)
     local plantData = {
-        ["plantCoords"] = {["x"] = plyCoords.x, ["y"] = plyCoords.y, ["z"] = plyCoords.z},
+        ["plantCoords"] = {["x"] = plantCoords.x, ["y"] = plantCoords.y, ["z"] = plantCoords.z},
         ["plantModel"] = QBWeed.Plants[type]["stages"]["stage-a"],
         ["plantLabel"] = QBWeed.Plants[type]["label"]
     }
-    local ClosestPlant = 0
-    for _, v in pairs(QBWeed.Props) do
-        if ClosestPlant == 0 then
-            ClosestPlant = GetClosestObjectOfType(plyCoords.x, plyCoords.y, plyCoords.z, 0.8, GetHashKey(v), false, false, false)
-        end
-    end
 
-    if currentHouse ~= nil then
-        if ClosestPlant == 0 then
+    LocalPlayer.state:set("inv_busy", true, true)
+    QBCore.Functions.Progressbar("plant_weed_plant", Lang:t('text.planting'), 8000, false, true, {
+        disableMovement = true,
+        disableCarMovement = true,
+        disableMouse = false,
+        disableCombat = true,
+    }, {
+        animDict = "amb@world_human_gardener_plant@male@base",
+        anim = "base",
+        flags = 16,
+        LocalPlayer.state:set("inv_busy", false, true)
+    }, {}, {}, function() -- Done
+        ClearPedTasks(ped)
+        TriggerServerEvent('qb-weed:server:placePlant', json.encode(plantData["plantCoords"]), type, currentHouse)
+        TriggerServerEvent('qb-weed:server:removeSeed', item.slot, type)
+    end, function() -- Cancel
+        ClearPedTasks(ped)
+        QBCore.Functions.Notify(Lang:t('error.process_canceled'), "error")
+        LocalPlayer.state:set("inv_busy", false, true)
+    end)
+end)
+
+RegisterNetEvent('qb-weed:client:foodPlant', function()
+    if not currentHouse then return end
+    if closestPlant ~= 0 then
+        local ped = PlayerPedId()
+        local plantData = getPlantData()
+
+        if plantData["plantStats"]["food"] == 100 then
+            QBCore.Functions.Notify(Lang:t('error.not_need_nutrition'), 'error', 3500)
+        else
             LocalPlayer.state:set("inv_busy", true, true)
-            QBCore.Functions.Progressbar("plant_weed_plant", Lang:t('text.planting'), 8000, false, true, {
+            QBCore.Functions.Progressbar("plant_weed_plant", Lang:t('text.feeding_plant'), math.random(4000, 8000), false, true, {
                 disableMovement = true,
                 disableCarMovement = true,
                 disableMouse = false,
                 disableCombat = true,
             }, {
-                animDict = "amb@world_human_gardener_plant@male@base",
-                anim = "base",
+                animDict = "timetable@gardener@filling_can",
+                anim = "gar_ig_5_filling_can",
                 flags = 16,
+
                 LocalPlayer.state:set("inv_busy", false, true)
             }, {}, {}, function() -- Done
                 ClearPedTasks(ped)
-                TriggerServerEvent('qb-weed:server:placePlant', json.encode(plantData["plantCoords"]), type, currentHouse)
-                TriggerServerEvent('qb-weed:server:removeSeed', item.slot, type)
+                local newFood = math.random(40, 60)
+                TriggerServerEvent('qb-weed:server:foodPlant', currentHouse, newFood, plantData["plantSort"]["name"], plantData["plantStats"]["plantId"])
             end, function() -- Cancel
                 ClearPedTasks(ped)
-                QBCore.Functions.Notify(Lang:t('error.process_canceled'), "error")
                 LocalPlayer.state:set("inv_busy", false, true)
+                QBCore.Functions.Notify(Lang:t('error.process_canceled'), "error")
             end)
-        else
-            QBCore.Functions.Notify(Lang:t('error.cant_place_here'), 'error', 3500)
-        end
-    else
-        QBCore.Functions.Notify(Lang:t('error.not_safe_here'), 'error', 3500)
-    end
-end)
-
-RegisterNetEvent('qb-weed:client:foodPlant', function()
-    if not currentHouse then return end
-    if ClosestTarget ~= 0 then
-        local ped = PlayerPedId()
-        local gender = "M"
-        if housePlants[currentHouse][ClosestTarget].gender == "woman" then
-            gender = "F"
-        end
-
-        local plantData = {
-            ["plantCoords"] = json.decode(housePlants[currentHouse][ClosestTarget].coords),
-            ["plantStage"] = housePlants[currentHouse][ClosestTarget].stage,
-            ["plantProp"] = GetHashKey(QBWeed.Plants[housePlants[currentHouse][ClosestTarget].sort]["stages"][housePlants[currentHouse][ClosestTarget].stage]),
-            ["plantSort"] = {
-                ["name"] = housePlants[currentHouse][ClosestTarget].sort,
-                ["label"] = QBWeed.Plants[housePlants[currentHouse][ClosestTarget].sort]["label"],
-            },
-            ["plantStats"] = {
-                ["food"] = housePlants[currentHouse][ClosestTarget].food,
-                ["health"] = housePlants[currentHouse][ClosestTarget].health,
-                ["progress"] = housePlants[currentHouse][ClosestTarget].progress,
-                ["stage"] = housePlants[currentHouse][ClosestTarget].stage,
-                ["highestStage"] = QBWeed.Plants[housePlants[currentHouse][ClosestTarget].sort]["highestStage"],
-                ["gender"] = gender,
-                ["plantId"] = housePlants[currentHouse][ClosestTarget].plantid,
-            }
-        }
-        local plyDistance = #(GetEntityCoords(ped) - vector3(plantData["plantCoords"].x, plantData["plantCoords"].y, plantData["plantCoords"].z))
-
-        if plyDistance < 1.0 then
-            if plantData["plantStats"]["food"] == 100 then
-                QBCore.Functions.Notify(Lang:t('error.not_need_nutrition'), 'error', 3500)
-            else
-                LocalPlayer.state:set("inv_busy", true, true)
-                QBCore.Functions.Progressbar("plant_weed_plant", Lang:t('text.feeding_plant'), math.random(4000, 8000), false, true, {
-                    disableMovement = true,
-                    disableCarMovement = true,
-                    disableMouse = false,
-                    disableCombat = true,
-                }, {
-                    animDict = "timetable@gardener@filling_can",
-                    anim = "gar_ig_5_filling_can",
-                    flags = 16,
-
-                    LocalPlayer.state:set("inv_busy", false, true)
-                }, {}, {}, function() -- Done
-                    ClearPedTasks(ped)
-                    local newFood = math.random(40, 60)
-                    TriggerServerEvent('qb-weed:server:foodPlant', currentHouse, newFood, plantData["plantSort"]["name"], plantData["plantStats"]["plantId"])
-                end, function() -- Cancel
-                    ClearPedTasks(ped)
-                    LocalPlayer.state:set("inv_busy", false, true)
-                    QBCore.Functions.Notify(Lang:t('error.process_canceled'), "error")
-                end)
-            end
-        else
-            QBCore.Functions.Notify(Lang:t('error.cant_place_here'), "error")
         end
     else
         QBCore.Functions.Notify(Lang:t('error.cant_place_here'), "error")

--- a/client/main.lua
+++ b/client/main.lua
@@ -41,8 +41,6 @@ local function spawnHousePlants()
     end)
 end
 
-
-
 local function despawnHousePlants()
     CreateThread(function()
         if plantSpawned then
@@ -73,13 +71,10 @@ RegisterNetEvent('qb-weed:client:getHousePlants', function(house)
     end, house)
 end)
 
-
-
-
 CreateThread(function()
     while true do
         Wait(0)
-        if insideHouse  and plantSpawned then
+        if insideHouse and plantSpawned then
             local ped = PlayerPedId()
             for k in pairs(housePlants[currentHouse]) do
                 local gender = (housePlants[currentHouse][k].gender == "woman") and "F" or "M"
@@ -162,8 +157,7 @@ CreateThread(function()
                     end
                 end
             end
-        end
-        if not insideHouse then
+        elseif not insideHouse then
             Wait(5000)
         end
     end

--- a/config.lua
+++ b/config.lua
@@ -1,106 +1,69 @@
 QBWeed = {}
 
-QBWeed.Progress = {
-    min = 1, -- Changing this will change growth time progression. Example 1 to 50 will give 50 progression in the 9.6 min cycle.
-    max = 3, -- see above, make sure max is more then min.
-} -- how much progress will be added to a healthy plant every 9.6 minutes
-
-QBWeed.showStages = true -- show the stages of the plants
-QBWeed.Stages = 'abcdefg' -- Stages the plants go through when growing
-
-QBWeed.Plants = {
-    ["ogkush"] = {
-        ["label"] = "OGKush 2g",
-        ["item"] = "weed_ogkush",
-        ["stages"] = {
-            ["stage-a"] = "bkr_prop_weed_01_small_01c",
-            ["stage-b"] = "bkr_prop_weed_01_small_01b",
-            ["stage-c"] = "bkr_prop_weed_01_small_01a",
-            ["stage-d"] = "bkr_prop_weed_med_01b",
-            ["stage-e"] = "bkr_prop_weed_lrg_01a",
-            ["stage-f"] = "bkr_prop_weed_lrg_01b",
-            ["stage-g"] = "bkr_prop_weed_lrg_01b",
-        },
-        ["highestStage"] = "stage-g"
-    },
-    ["amnesia"] = {
-        ["label"] = "Amnesia 2g",
-        ["item"] = "weed_amnesia",
-        ["stages"] = {
-            ["stage-a"] = "bkr_prop_weed_01_small_01c",
-            ["stage-b"] = "bkr_prop_weed_01_small_01b",
-            ["stage-c"] = "bkr_prop_weed_01_small_01a",
-            ["stage-d"] = "bkr_prop_weed_med_01b",
-            ["stage-e"] = "bkr_prop_weed_lrg_01a",
-            ["stage-f"] = "bkr_prop_weed_lrg_01b",
-            ["stage-g"] = "bkr_prop_weed_lrg_01b",
-        },
-        ["highestStage"] = "stage-g"
-    },
-    ["skunk"] = {
-        ["label"] = "Skunk 2g",
-        ["item"] = "weed_skunk",
-        ["stages"] = {
-            ["stage-a"] = "bkr_prop_weed_01_small_01c",
-            ["stage-b"] = "bkr_prop_weed_01_small_01b",
-            ["stage-c"] = "bkr_prop_weed_01_small_01a",
-            ["stage-d"] = "bkr_prop_weed_med_01b",
-            ["stage-e"] = "bkr_prop_weed_lrg_01a",
-            ["stage-f"] = "bkr_prop_weed_lrg_01b",
-            ["stage-g"] = "bkr_prop_weed_lrg_01b",
-        },
-        ["highestStage"] = "stage-g"
-    },
-    ["ak47"] = {
-        ["label"] = "AK47 2g",
-        ["item"] = "weed_ak47",
-        ["stages"] = {
-            ["stage-a"] = "bkr_prop_weed_01_small_01c",
-            ["stage-b"] = "bkr_prop_weed_01_small_01b",
-            ["stage-c"] = "bkr_prop_weed_01_small_01a",
-            ["stage-d"] = "bkr_prop_weed_med_01b",
-            ["stage-e"] = "bkr_prop_weed_lrg_01a",
-            ["stage-f"] = "bkr_prop_weed_lrg_01b",
-            ["stage-g"] = "bkr_prop_weed_lrg_01b",
-        },
-        ["highestStage"] = "stage-g"
-    },
-    ["purplehaze"] = {
-        ["label"] = "Purple Haze 2g",
-        ["item"] = "weed_purplehaze",
-        ["stages"] = {
-            ["stage-a"] = "bkr_prop_weed_01_small_01c",
-            ["stage-b"] = "bkr_prop_weed_01_small_01b",
-            ["stage-c"] = "bkr_prop_weed_01_small_01a",
-            ["stage-d"] = "bkr_prop_weed_med_01b",
-            ["stage-e"] = "bkr_prop_weed_lrg_01a",
-            ["stage-f"] = "bkr_prop_weed_lrg_01b",
-            ["stage-g"] = "bkr_prop_weed_lrg_01b",
-        },
-        ["highestStage"] = "stage-g"
-    },
-    ["whitewidow"] = {
-        ["label"] = "White Widow 2g",
-        ["item"] = "weed_whitewidow",
-        ["stages"] = {
-            ["stage-a"] = "bkr_prop_weed_01_small_01c",
-            ["stage-b"] = "bkr_prop_weed_01_small_01b",
-            ["stage-c"] = "bkr_prop_weed_01_small_01a",
-            ["stage-d"] = "bkr_prop_weed_med_01b",
-            ["stage-e"] = "bkr_prop_weed_lrg_01a",
-            ["stage-f"] = "bkr_prop_weed_lrg_01b",
-            ["stage-g"] = "bkr_prop_weed_lrg_01b",
-        },
-        ["highestStage"] = "stage-g"
-    },
+QBWeed.Progress = {         -- How much progress will be added to a healthy plant every GrowthTick
+    min = 1,                -- Changing this will change growth time progression. Example 1 to 50 will give 50 progression in the 9.6 min cycle.
+    max = 3,                -- See above, make sure max is more then min.
 }
 
-QBWeed.Props = {
-    ["stage-a"] = "bkr_prop_weed_01_small_01c",
-    ["stage-b"] = "bkr_prop_weed_01_small_01b",
-    ["stage-c"] = "bkr_prop_weed_01_small_01a",
-    ["stage-d"] = "bkr_prop_weed_med_01b",
-    ["stage-e"] = "bkr_prop_weed_lrg_01a",
-    ["stage-f"] = "bkr_prop_weed_lrg_01b",
-    ["stage-g"] = "bkr_prop_weed_lrg_01b",
+QBWeed.ShowStages = true    -- Show the stages of the plants
+QBWeed.GrowthTick = 9.6     -- Amount of time (in mins) to increase plant growth & update health / nutrition (every second tick)
+QBWeed.FoodUsage = 1        -- Amount of food to use per-tick
+
+QBWeed.StageLabels = {
+    [1] = "Germination",
+    [2] = "Seedling",
+    [3] = "Vegetative",
+    [4] = "Budding",
+    [5] = "Pre-flowering",
+    [6] = "Flowering",
+    [7] = "Ready for harvest",
+}
+
+QBWeed.DefaultProps = {
+    [1] = "bkr_prop_weed_01_small_01c",
+    [2] = "bkr_prop_weed_01_small_01b",
+    [3] = "bkr_prop_weed_01_small_01a",
+    [4] = "bkr_prop_weed_med_01b",
+    [5] = "bkr_prop_weed_lrg_01a",
+    [6] = "bkr_prop_weed_lrg_01b",
+    [7] = "bkr_prop_weed_lrg_01b",
+}
+
+QBWeed.Plants = {
+    ogkush = {
+        label = "OGKush 2g",
+        item = "weed_ogkush",
+        stages = QBWeed.DefaultProps,
+        highestStage = 7,
+    },
+    amnesia = {
+        label = "Amnesia 2g",
+        item = "weed_amnesia",
+        stages = QBWeed.DefaultProps,
+        highestStage = 7,
+    },
+    skunk = {
+        label = "Skunk 2g",
+        item = "weed_skunk",
+        stages = QBWeed.DefaultProps,
+        highestStage = 7,
+    },
+    ak47 = {
+        label = "AK47 2g",
+        item = "weed_ak47",
+        stages = QBWeed.DefaultProps,
+        highestStage = 7,
+    },
+    purplehaze = {
+        label = "Purple Haze 2g",
+        item = "weed_purplehaze",
+        stages = QBWeed.DefaultProps,
+        highestStage = 7,
+    },
+    whitewidow = {
+        label = "White Widow 2g",
+        item = "weed_whitewidow",
+        stages = QBWeed.DefaultProps,
+        highestStage = 7,
+    },
 }

--- a/config.lua
+++ b/config.lua
@@ -6,6 +6,7 @@ QBWeed.Progress = {
 } -- how much progress will be added to a healthy plant every 9.6 minutes
 
 QBWeed.showStages = true -- show the stages of the plants
+QBWeed.Stages = 'abcdefg' -- Stages the plants go through when growing
 
 QBWeed.Plants = {
     ["ogkush"] = {

--- a/qb-weed.sql
+++ b/qb-weed.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `house_plants` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `building` varchar(50) DEFAULT NULL,
-  `stage` varchar(50) DEFAULT 'stage-a',
+  `stage` int(11) DEFAULT 1,
   `sort` varchar(50) DEFAULT NULL,
   `gender` varchar(50) DEFAULT NULL,
   `food` int(11) DEFAULT 100,
@@ -13,3 +13,13 @@ CREATE TABLE IF NOT EXISTS `house_plants` (
   KEY `building` (`building`),
   KEY `plantid` (`plantid`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- Update January 15, 2024
+UPDATE `house_plants` SET `stage` = 1 WHERE `stage` = 'stage-a';
+UPDATE `house_plants` SET `stage` = 2 WHERE `stage` = 'stage-b';
+UPDATE `house_plants` SET `stage` = 3 WHERE `stage` = 'stage-c';
+UPDATE `house_plants` SET `stage` = 4 WHERE `stage` = 'stage-d';
+UPDATE `house_plants` SET `stage` = 5 WHERE `stage` = 'stage-e';
+UPDATE `house_plants` SET `stage` = 6 WHERE `stage` = 'stage-f';
+UPDATE `house_plants` SET `stage` = 7 WHERE `stage` = 'stage-g';
+ALTER TABLE `house_plants` MODIFY COLUMN `stage` int(11) DEFAULT 1;

--- a/server/main.lua
+++ b/server/main.lua
@@ -109,35 +109,22 @@ CreateThread(function()
                         {(housePlants[k].progress + Grow), housePlants[k].plantid})
                 elseif housePlants[k].progress + Grow >= 100 then
                     if housePlants[k].stage ~= QBWeed.Plants[housePlants[k].sort]["highestStage"] then
-                        local nextStageInd = QBWeed.Stages:find(housePlants[k].stage:gsub('stage-', '')) + 1
-                        local nextStage = QBWeed.Stages:sub(nextStageInd, nextStageInd)
-
-                        if nextStage then
-                            MySQL.update('UPDATE house_plants SET stage = ?, progress = 0 WHERE plantid = ?',
-                                {'stage-' .. nextStage, housePlants[k].plantid})
-                        end
+                        MySQL.update('UPDATE house_plants SET stage = ?, progress = 0 WHERE plantid = ?',
+                            {housePlants[k].stage + 1, housePlants[k].plantid})
                     end
                 end
             end
             if healthTick then
-                local plantFood = plant.food
-                local plantHealth = plant.health
-
-                if plantFood >= 50 then
-                    plantFood = math.max(0, plantFood - 1)
-                    plantHealth = math.min(100, plantHealth + 1)
-                else
-                    plantFood = math.max(0, plantFood - 1)
-                    plantHealth = math.max(0, plantHealth - 1)
-                end
+                local plantFood = math.max(0, plant.food - QBWeed.FoodUsage)
+                local plantHealth = (plantFood >= 50) and math.min(100, plant.health + 1) or math.max(0, plant.health - 1)
 
                 MySQL.update('UPDATE house_plants SET food = ?, health = ? WHERE plantid = ?',
                     {plantFood, plantHealth, plant.plantid})
             end
         end
 
-        TriggerClientEvent('qb-weed:client:refreshPlantStats', -1)
+        TriggerClientEvent('qb-weed:client:refreshHousePlants', -1)
         healthTick = not healthTick
-        Wait((60 * 1000) * 9.6)
+        Wait((60 * 1000) * QBWeed.GrowthTick)
     end
 end)


### PR DESCRIPTION
**Describe Pull request**
Adds more configurable stages to the growth process. Cleanup & optimizations.

Changes:
- General syntax fixes & cleanup
- Change stages to numeric w/ labels
- Optimize threads & distance checks
- Remove redundant client event (`qb-weed:client:refreshPlantStats`)
- Add SQL change:
  - Modify stages from varchar to int
- Add config options:
  - QBWeed.GrowthTick - Allows tuning of the growth / health check tick
  - QBWeed.FoodUsage - Allows control over the amount of food used per tick
- Fixed a bug where you couldn't plant your first seed in a home

We should probably move over to PZs & qb-target for this resource at some point, but these changes at least optimize the current functionality. 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
